### PR TITLE
エラーモジュール追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ composer require pj8/sentry-module
 ```php
 use BEAR\Package\AbstractAppModule;
 use BEAR\Package\Context\ProdModule as PackageProdModule;
-use BEAR\Sunday\Extension\Error\ErrorInterface;
 use Pj8\SentryModule\SentryModule;
-use Pj8\SentryModule\SentryErrorHandler;
+use Pj8\SentryModule\SentryErrorModule;
 
 class ProdModule extends AbstractAppModule
 {
@@ -34,8 +33,7 @@ class ProdModule extends AbstractAppModule
     {
         $this->install(new PackageProdModule());
         $this->install(new SentryModule(['dsn' => 'https://secret@sentry.example.com/1"']));
-        $this->rename(ErrorInterface::class, 'original');
-        $this->bind(ErrorInterface::class)->to(SentryErrorHandler::class);
+        $this->install(new SentryErrorModule($this));
     }
 }
 ```

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pj8\SentryModule\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException
+{
+}

--- a/src/SentryErrorModule.php
+++ b/src/SentryErrorModule.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pj8\SentryModule;
+
+use BEAR\Sunday\Extension\Error\ErrorInterface;
+use Pj8\SentryModule\Exception\InvalidArgumentException;
+use Ray\Di\AbstractModule;
+
+class SentryErrorModule extends AbstractModule
+{
+    public function __construct(?AbstractModule $module = null)
+    {
+        if ($module === null) {
+            throw new InvalidArgumentException('module is required');
+        }
+
+        parent::__construct($module);
+        $module->rename(ErrorInterface::class, 'original');
+    }
+
+    protected function configure(): void
+    {
+        $this->bind(ErrorInterface::class)->to(SentryErrorHandler::class);
+    }
+}

--- a/tests/SentryErrorModuleTest.php
+++ b/tests/SentryErrorModuleTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Pj8\SentryModule;
+
+use PHPUnit\Framework\TestCase;
+use Pj8\SentryModule\Exception\InvalidArgumentException;
+
+class SentryErrorModuleTest extends TestCase
+{
+    public function testConstructorThrowsExceptionCaseNull(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new SentryErrorModule();
+    }
+}


### PR DESCRIPTION
### 変更前

アプリケーションで下記の束縛をしていた。

```php
        $this->rename(ErrorInterface::class, 'original');
        $this->bind(ErrorInterface::class)->to(SentryErrorHandler::class);
```

### 変更後

SentryErrorModule  を作成し、それをインストールすることだけで同じことができるようにする。
