### PR TITLE
Composer allow-plugins 追加と GithubActions 修正

### DIFF
--- a/.github/workflows/static-analytics.yml
+++ b/.github/workflows/static-analytics.yml
@@ -125,6 +125,7 @@ jobs:
         with:
           php-version: 8.0
           coverage: none
+          tools: composer-require-checker
 
       - name: Get composer cache directory
         id: composer-cache
@@ -133,7 +134,6 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-interaction --no-progress --prefer-dist
-          composer require --dev maglnet/composer-require-checker ^3.0
 
       - name: Run composer-require-checker
-        run: ./vendor/bin/composer-require-checker --config-file=./composer-require-checker.json
+        run: composer-require-checker --config-file=./composer-require-checker.json

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,9 @@
         "build": ["@cs", "@sa", "@pcov"]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,7 +34,6 @@
         <exclude-pattern>*/tmp/*</exclude-pattern>
 
         <!-- level 2: 自動修正 Riskyルール -->
-        <!-- <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>　-->
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing"/>
         <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
         <exclude-pattern>*/tests/Fake/*</exclude-pattern>
@@ -64,6 +63,9 @@
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
         <include-pattern>src/*</include-pattern>
         <include-pattern>tests/*</include-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>src/IncludesMatcher.php</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.PropertySpacing">
         <properties>

--- a/tests/ExcludeSamplerTest.php
+++ b/tests/ExcludeSamplerTest.php
@@ -55,7 +55,7 @@ class ExcludeSamplerTest extends TestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return string[][]
      */
     public function getSampleExcludeData(): array
     {

--- a/tests/IncludesMatcherTest.php
+++ b/tests/IncludesMatcherTest.php
@@ -27,7 +27,7 @@ class IncludesMatcherTest extends TestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return ReflectionMethod[][]
      */
     public function getHttpMethodData(): array
     {
@@ -40,7 +40,7 @@ class IncludesMatcherTest extends TestCase
     }
 
     /**
-     * @return mixed[][]
+     * @return ReflectionMethod[][]
      */
     public function getUnrelatedMethodData(): array
     {


### PR DESCRIPTION
## 変更内容

- Composer allow-plugins が設定されていない問題を修正 f3a4727
- GithubActions で [composer-require-checker の依存解決ができなくなっていた問題](https://github.com/pj8/Pj8.SentryModule/runs/5017529800?check_suite_focus=true) を修正 954f81c
- [CSエラーになっていた問題](https://github.com/pj8/Pj8.SentryModule/runs/5017529863?check_suite_focus=true) を修正するためCS設定変更 355dc7c

テストのCS改善も併せて行いました 214a8b6
