### PR TITLE
Renovate 設定追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:base"
+    ],
+    "timezone": "Asia/Tokyo",
+    "schedule": ["after 10am on Monday"],
+    "labels": ["renovate", "dependencies"],
+    "lockFileMaintenance": {
+        "enabled": false
+    },
+    "prConcurrentLimit": 4,
+    "prHourlyLimit": 2,
+    "rangeStrategy": "bump",
+    "dependencyDashboard": true,
+    "packageRules": [
+        {
+            "matchManagers": ["composer"],
+            "matchUpdateTypes": ["patch", "minor", "major"],
+            "matchDepTypes": ["require", "require-dev"],
+            "groupName": "Composer dependencies",
+            "groupSlug": "composer-dependencies",
+            "labels": ["renovate", "dependencies"],
+            "excludePackagePrefixes": ["bear", "ray"]
+        }
+    ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,8 @@
     "prHourlyLimit": 2,
     "rangeStrategy": "bump",
     "dependencyDashboard": true,
+    "ignorePaths": ["vendor-bin"],
+    "ignoreDeps": ["bear/package", "bear/resource", "bear/sunday", "ray/aop", "ray/di"],
     "packageRules": [
         {
             "matchManagers": ["composer"],
@@ -21,8 +23,7 @@
             "groupName": "Composer dependencies",
             "groupSlug": "composer-dependencies",
             "labels": ["renovate", "dependencies"],
-            "automerge": false,
-            "excludePackageNames": ["bear/package", "bear/resource", "bear/sunday", "ray/aop", "ray/di"]
+            "automerge": false
         }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     },
     "prConcurrentLimit": 4,
     "prHourlyLimit": 2,
-    "rangeStrategy": "bump",
+    "rangeStrategy": "replace",
     "dependencyDashboard": true,
     "packageRules": [
         {
@@ -21,6 +21,7 @@
             "groupName": "Composer dependencies",
             "groupSlug": "composer-dependencies",
             "labels": ["renovate", "dependencies"],
+            "automerge": false,
             "excludePackagePrefixes": ["bear", "ray"]
         }
     ]

--- a/renovate.json
+++ b/renovate.json
@@ -4,14 +4,14 @@
         "config:base"
     ],
     "timezone": "Asia/Tokyo",
-    "schedule": ["after 10am on Monday"],
+    "schedule": ["after 10am on Monday", "before 11am on Monday"],
     "labels": ["renovate", "dependencies"],
     "lockFileMaintenance": {
         "enabled": false
     },
     "prConcurrentLimit": 4,
     "prHourlyLimit": 2,
-    "rangeStrategy": "replace",
+    "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "packageRules": [
         {
@@ -22,7 +22,7 @@
             "groupSlug": "composer-dependencies",
             "labels": ["renovate", "dependencies"],
             "automerge": false,
-            "excludePackagePrefixes": ["bear", "ray"]
+            "excludePackageNames": ["bear/package", "bear/resource", "bear/sunday", "ray/aop", "ray/di"]
         }
     ]
 }


### PR DESCRIPTION
[GitHub App Renovate](https://github.com/apps/renovate) を設定します。

- `excludePackageNames` は想定するユーザーの利用バージョンに合わせるために指定しました
- パッチの automerge 設定とパス vendor-bin/tools/composer.json への設定追加を予定していますが、後日別PRで行いたいと思います
