### PR TITLE
PHPStan 設定変更

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,4 @@ parameters:
   paths:
     - src
     - tests
+  checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
下記のように静的解析ビルドエラーになったため対応しました。
https://github.com/pj8/Pj8.SentryModule/runs/5546758474?check_suite_focus=true

PHPStan で不必要なテンプレートエラーを避けるため
`checkGenericClassInNonGenericObjectType: false`
を設定しました。