### PR TITLE
before_sendイベントでタグを付与する処理の追加

### DIFF
--- a/src/BeforeSend.php
+++ b/src/BeforeSend.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pj8\SentryModule;
+
+use Sentry\Event;
+
+final class BeforeSend implements BeforeSendInterface
+{
+    /** @param array<string, string> $tags セットしたいタグの配列(オプション) */
+    public function __construct(private readonly array $tags = [])
+    {
+    }
+
+    public function __invoke(Event $event): Event
+    {
+        if ($this->tags !== []) {
+            $event->setTags($this->tags);
+        }
+
+        return $event;
+    }
+}

--- a/src/BeforeSendInterface.php
+++ b/src/BeforeSendInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pj8\SentryModule;
+
+use Sentry\Event;
+
+interface BeforeSendInterface
+{
+    public function __invoke(Event $event): Event|null;
+}

--- a/tests/BeforeSendTest.php
+++ b/tests/BeforeSendTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pj8\SentryModule;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+
+class BeforeSendTest extends TestCase
+{
+    public function testInvokeSetServiceNameTag(): void
+    {
+        $tags = ['service' => 'test-service'];
+        $beforeSend = new BeforeSend($tags);
+        $event = Event::createEvent();
+
+        $modifiedEvent = $beforeSend($event);
+
+        $this->assertSame('test-service', $modifiedEvent->getTags()['service']);
+    }
+
+    public function testInvokeNotSetServiceNameTag(): void
+    {
+        $beforeSend = new BeforeSend();
+        $event = Event::createEvent();
+
+        $modifiedEvent = $beforeSend($event);
+
+        $this->assertEmpty($modifiedEvent->getTags());
+    }
+}


### PR DESCRIPTION
## 対応内容
- Sentry SDKを使ってDatadogのDSNへエラーログを送信するとき、タグを付けないとservice名がデフォルトで `sentry-service`になってしまうため、before_sendイベントでタグを付与できる機能を追加しました

before_sendイベントは下記のSentryドキュメントを参照してください
https://docs.sentry.io/platforms/php/configuration/filtering/#using-before-send