### PR TITLE
doctrine annotations を除去してPHP 8 Attribute に移行

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -3,7 +3,6 @@
         "null", "true", "false",
         "static", "self", "parent",
         "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object", "mixed",
-        "Doctrine\\Common\\Cache\\ArrayCache", "Doctrine\\Common\\Cache\\Cache",
         "BEAR\\Resource\\ResourceObject",
         "BEAR\\Sunday\\Extension\\Error\\ErrorInterface",
         "BEAR\\Sunday\\Extension\\Error\\ThrowableHandlerInterface",

--- a/src/Annotation/Monitorable.php
+++ b/src/Annotation/Monitorable.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Pj8\SentryModule\Annotation;
 
-/**
- * @Annotation
- * @Target("METHOD")
- */
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
 final class Monitorable
 {
 }

--- a/src/SentryErrorHandler.php
+++ b/src/SentryErrorHandler.php
@@ -15,9 +15,10 @@ class SentryErrorHandler implements ErrorInterface
 {
     private ErrorInterface $originalError;
 
-    /** @Named("original=original") */
-    public function __construct(ErrorInterface $original)
-    {
+    public function __construct(
+        #[Named('original')]
+        ErrorInterface $original,
+    ) {
         $this->originalError = $original;
     }
 

--- a/src/SentryThrowableHandler.php
+++ b/src/SentryThrowableHandler.php
@@ -15,9 +15,10 @@ class SentryThrowableHandler implements ThrowableHandlerInterface
 {
     private ThrowableHandlerInterface $originalHandler;
 
-    /** @Named("original=original") */
-    public function __construct(ThrowableHandlerInterface $original)
-    {
+    public function __construct(
+        #[Named('original')]
+        ThrowableHandlerInterface $original,
+    ) {
         $this->originalHandler = $original;
     }
 


### PR DESCRIPTION
## Summary
* doctrine/annotations 依存を除去します
  - `Monitorable` クラスの `@Annotation` / `@Target("METHOD")` docblock を `#[Attribute(Attribute::TARGET_METHOD)]` に置換
  - `composer-require-checker.json` から不要な `Doctrine\Common\Cache` の whitelist エントリを削除
* #63 は docblock アノテーションのアトリビュート移行に踏み込んでおらず、doctrine/annotations 依存がない利用先にインストールすると問題が起きるリスクが残存していました。本件で完全除去を行います。

## Test plan
- [x] PHPUnit 全38テスト通過
- [x] PHPStan エラーなし
- [x] Psalm エラーなし
- [x] PHPCS 違反なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * PHP 8+の最新標準への対応強化のため、内部的なコード構造を現代化しました。古い注釈手法から新しいメカニズムへ移行し、依存関係管理の設定も最適化しています。ユーザー向け機能に対する変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->